### PR TITLE
Docs: Add `no-await-in-loop` doc

### DIFF
--- a/docs/rules/errors/README.md
+++ b/docs/rules/errors/README.md
@@ -12,7 +12,7 @@ unexpected behavior.
 | [for-direction](./for-direction.md) | Disallow for loops which update their counter in the wrong direction. |
 | [getter-return](./getter-return.md) | Disallow getter properties which do not always return a value. |
 | [no-async-promise-executor](./no-async-promise-executor.md) | Disallow async functions as promise executors. |
-| [no-await-in-loop](./no-await-in-loop.md) | Disallow await inside of loop. |
+| [no-await-in-loop](./no-await-in-loop.md) | Disallow await inside of loops. |
 | [no-compare-neg-zero](./no-compare-neg-zero.md) | Disallow comparison against `-0` which yields unexpected behavior. |
 | [no-cond-assign](./no-cond-assign.md) | Forbid the use of assignment expressions in conditions which may yield unwanted behavior. |
 | [no-constant-condition](./no-constant-condition.md) | Disallow constant conditions which always yield one result. |

--- a/docs/rules/errors/README.md
+++ b/docs/rules/errors/README.md
@@ -12,7 +12,7 @@ unexpected behavior.
 | [for-direction](./for-direction.md) | Disallow for loops which update their counter in the wrong direction. |
 | [getter-return](./getter-return.md) | Disallow getter properties which do not always return a value. |
 | [no-async-promise-executor](./no-async-promise-executor.md) | Disallow async functions as promise executors. |
-| [no-await-in-loop](./no-await-in-loop.md) |  |
+| [no-await-in-loop](./no-await-in-loop.md) | Disallow await inside of loop. |
 | [no-compare-neg-zero](./no-compare-neg-zero.md) | Disallow comparison against `-0` which yields unexpected behavior. |
 | [no-cond-assign](./no-cond-assign.md) | Forbid the use of assignment expressions in conditions which may yield unwanted behavior. |
 | [no-constant-condition](./no-constant-condition.md) | Disallow constant conditions which always yield one result. |

--- a/docs/rules/errors/no-await-in-loop.md
+++ b/docs/rules/errors/no-await-in-loop.md
@@ -3,11 +3,11 @@
 -->
 # no-await-in-loop
 
-Disallow await inside of loop.
+Disallow await inside of loops.
 
 You may want to `await` a promise until it is fulfilled or rejected, inside of loops. In such cases, to take
-performance advantages of concurrency with async operations, you should be careful __not__ to `await` in each
-iteration; otherwise your async operations would be executed in serial.
+full advantage of concurrency, you should __not__ `await` the promise in every iteration, otherwise your async
+operations will be executed serially.
 Generally it is recommended that you create all promises, then use `Promise.all` for them. This way your async
 operations will be performed concurrently.
 

--- a/docs/rules/errors/no-await-in-loop.md
+++ b/docs/rules/errors/no-await-in-loop.md
@@ -3,6 +3,40 @@
 -->
 # no-await-in-loop
 
+Disallow await inside of loop.
+
+You may want to `await` a promise until it is fulfilled or rejected, inside of loops. In such cases, to take
+performance advantages of concurrency with async operations, you should be careful __not__ to `await` in each
+iteration; otherwise your async operations would be executed in serial.
+Generally it is recommended that you create all promises, then use `Promise.all` for them. This way your async
+operations will be performed concurrently.
+
+## Incorrect Code Exapmles
+
+```js
+async function foo(xs) {
+    const results = [];
+    for (const x of xs) {
+        // iteration does not proceed until `bar(x)` completes
+        results.push(await bar(x));
+    }
+    return baz(results);
+}
+```
+
+## Correct Code Examples
+
+```js
+async function foo(xs) {
+    const results = [];
+    for (const x of xs) {
+        // push a promise to the array; it does not prevent the iteration
+        results.push(bar(x));
+    }
+    // we wait for all the promises concurrently
+    return baz(await Promise.all(results));
+}
+```
 
 <details>
  <summary> More incorrect examples </summary>

--- a/rslint_core/src/groups/errors/no_await_in_loop.rs
+++ b/rslint_core/src/groups/errors/no_await_in_loop.rs
@@ -2,6 +2,42 @@ use crate::rule_prelude::*;
 use SyntaxKind::*;
 
 declare_lint! {
+    /**
+    Disallow await inside of loop.
+
+    You may want to `await` a promise until it is fulfilled or rejected, inside of loops. In such cases, to take
+    performance advantages of concurrency with async operations, you should be careful __not__ to `await` in each
+    iteration; otherwise your async operations would be executed in serial.
+    Generally it is recommended that you create all promises, then use `Promise.all` for them. This way your async
+    operations will be performed concurrently.
+
+    ## Incorrect Code Exapmles
+
+    ```ignore
+    async function foo(xs) {
+        const results = [];
+        for (const x of xs) {
+            // iteration does not proceed until `bar(x)` completes
+            results.push(await bar(x));
+        }
+        return baz(results);
+    }
+    ```
+
+    ## Correct Code Examples
+
+    ```ignore
+    async function foo(xs) {
+        const results = [];
+        for (const x of xs) {
+            // push a promise to the array; it does not prevent the iteration
+            results.push(bar(x));
+        }
+        // we wait for all the promises concurrently
+        return baz(await Promise.all(results));
+    }
+    ```
+    */
     #[derive(Default)]
     NoAwaitInLoop,
     errors,

--- a/rslint_core/src/groups/errors/no_await_in_loop.rs
+++ b/rslint_core/src/groups/errors/no_await_in_loop.rs
@@ -3,11 +3,11 @@ use SyntaxKind::*;
 
 declare_lint! {
     /**
-    Disallow await inside of loop.
+    Disallow await inside of loops.
 
     You may want to `await` a promise until it is fulfilled or rejected, inside of loops. In such cases, to take
-    performance advantages of concurrency with async operations, you should be careful __not__ to `await` in each
-    iteration; otherwise your async operations would be executed in serial.
+    full advantage of concurrency, you should __not__ `await` the promise in every iteration, otherwise your async
+    operations will be executed serially.
     Generally it is recommended that you create all promises, then use `Promise.all` for them. This way your async
     operations will be performed concurrently.
 


### PR DESCRIPTION
This PR adds a doc for `no-await-in-loop`. Closes #1 
I referred to other rules doc and tried to follow the writing manner, but if I missed something please tell me.

PS.
Generating doc by running `cargo docgen` is a really good developer experience for me :smiley: 
And I looked over what you suggested to me at the issue comment, which allowed me to learn how RSLint works as a whole! Now I'm kind of convinced that RSLint has a lot of advantages over deno_lint - I almost wish we could replace the core of deno_lint with RSLint :laughing: 