### PR TITLE
Chore: allow macros to deal with trailing commas

### DIFF
--- a/rslint_core/src/groups/errors/mod.rs
+++ b/rslint_core/src/groups/errors/mod.rs
@@ -21,5 +21,5 @@ group! {
     no_inner_declarations::NoInnerDeclarations,
     no_irregular_whitespace::NoIrregularWhitespace,
     no_prototype_builtins::NoPrototypeBuiltins,
-    no_sparse_arrays::NoSparseArrays
+    no_sparse_arrays::NoSparseArrays,
 }

--- a/rslint_core/src/groups/mod.rs
+++ b/rslint_core/src/groups/mod.rs
@@ -6,7 +6,7 @@ pub use errors::errors;
 /// This will call `::new()` on each rule.  
 #[macro_export]
 macro_rules! group {
-    ($(#[$description:meta])* $groupname:ident, $($path:ident::$rule:ident),*) => {
+    ($(#[$description:meta])* $groupname:ident, $($path:ident::$rule:ident),* $(,)?) => {
         use $crate::CstRule;
         $(
             mod $path;

--- a/rslint_core/src/rule.rs
+++ b/rslint_core/src/rule.rs
@@ -237,7 +237,7 @@ macro_rules! declare_lint {
             $(
                 $(#[$inner:meta])*
                 $visibility:vis $key:ident : $val:ty
-            ),*
+            ),* $(,)?
         )?
     ) => {
         use $crate::Rule;
@@ -270,5 +270,5 @@ macro_rules! declare_lint {
                 stringify!($group)
             }
         }
-    }
+    };
 }

--- a/rslint_core/src/testing.rs
+++ b/rslint_core/src/testing.rs
@@ -19,7 +19,7 @@ macro_rules! rule_tests {
             // An optional tag to give to docgen
             $(#[$err_meta:meta])*
             $code:literal
-        ),*
+        ),* $(,)?
     },
 
     // Optional doc used in the user facing docs for the
@@ -30,8 +30,8 @@ macro_rules! rule_tests {
             // An optional tag to give to docgen
             $(#[$ok_meta:meta])*
             $ok_code:literal
-        ),*
-    }) => {
+        ),* $(,)?
+    } $(,)?) => {
         #[allow(unused_imports)]
         use $crate::run_rule;
         #[allow(unused_imports)]
@@ -53,11 +53,11 @@ macro_rules! rule_tests {
             $(
                 let res = parse_module($ok_code, 0);
                 let errs = run_rule(&(Box::new($rule) as Box<dyn CstRule>), 0, res.syntax(), true, &[]);
-    
+
                 if !errs.is_empty() {
                     panic!("\nExpected:\n```\n{}\n```\nto pass linting, but instead it threw errors (along with {} parsing errors):\n\n", $ok_code, res.errors().len());
                 }
             )*
         }
-    }
+    };
 }


### PR DESCRIPTION
This is a trivial patch, which allows macros (`group!`, `declare_lint!`,  `rule_tests!`) to handle input with trailing commas.

We will be able to write these macros like the following:

#### group!

```rust
group! {
    /// Rules which relate to productions which are almost always erroneous or cause
    /// unexpected behavior.
    errors,
    no_unsafe_finally::NoUnsafeFinally,
    no_sparse_arrays::NoSparseArrays, // <- trailing comma
}
```

#### declare_lint!

```rust
declare_lint! {
    /**
    foobar
    */
    SomeRule,
    errors,
    "foobar",
    pub some_option: bool, // <- trailing comma
}
```

#### rule_tests!

```rust
rule_tests! {
    SomeRule::default(),
    err: {
        "let foo = bar;", // <- trailing comma
    },
    ok: {
        "let foo = bar;", // <- trailing comma
    }, // <- trailing comma
}
```