### PR TITLE
Fix: allow `cons` method to work if there is no `else` block

### DIFF
--- a/rslint_parser/src/ast/stmt_ext.rs
+++ b/rslint_parser/src/ast/stmt_ext.rs
@@ -298,7 +298,7 @@ impl IfStmt {
             .child_with_ast::<Stmt>()
             .filter(|cons| {
                 cons.syntax().text_range().start()
-                    < self
+                    <= self
                         .else_token()
                         .map(|x| x.text_range().start())
                         .unwrap_or(cons.syntax().text_range().start())


### PR DESCRIPTION
Given this code:

```js
if (foo) {
  return 42;
}
```

When we want to get `{ return 42; }` block as `ast::Stmt`, I think we can use `cons` method like `if_stmt.cons()`.
Currently it works fine if `else` block exists. However, if there's no `else` just like the above code, `if_stmt.cons()` returns `None`, which seems strange to me.
This strange behavior is because if there's no `else`, the current logic in `cons` method filters out an stmt by checking whether `cons.syntax().text_range().start()` is smaller than _itself_, which is of course always false. Therefore, always we get `None` in such situations.

I guess this problem can be solved by checking in the "smaller than _or equal to_" way, not "smaller than". So I have fixed in this way.

I have two questions:

1. Is there no test about `stmt_ext.rs` at the moment? I want to make sure my fix works as expected by adding a test, but I couldn't find where and how.
2. Don't you use `rustfmt`? Huge number of diffs were generated when I fixed `stmt_ext.rs` and saved it. (my editor automatically applies `rustfmt` whenever files are saved)