### PR TITLE
Feat: add incremental reparsing, incremental relinting, and file watching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,15 +2,15 @@
 # It is not intended for manual editing.
 [[package]]
 name = "ahash"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d66721683190aeea775c737eee925aea24719058d86d815e8ee121dd9f37d19"
+checksum = "0adac150c2dd5a9c864d054e07bda5e6bc010cd10036ea5f17e82a2f5867f735"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.10"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
+checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 dependencies = [
  "memchr",
 ]
@@ -21,7 +21,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -30,14 +30,14 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
+checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 
 [[package]]
 name = "arrayvec"
@@ -53,14 +53,14 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base-x"
@@ -82,9 +82,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bstr"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2889e6d50f394968c8bf4240dc3f2a7eb4680844d27308f798229ac9d4725f41"
+checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.2.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
+checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "byteorder"
@@ -115,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.54"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
+checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
 
 [[package]]
 name = "cfg-if"
@@ -133,9 +133,9 @@ checksum = "1d29eb15132782371f71da8f947dba48b3717bdb6fa771b9b434d645e40a7193"
 
 [[package]]
 name = "clap"
-version = "2.33.0"
+version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term 0.11.0",
  "atty",
@@ -155,6 +155,17 @@ dependencies = [
  "serde",
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -182,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc755679c12bda8e5523a71e4d654b6bf2e14bd838dfc48cde6559a05caf7d1"
+checksum = "70daa7ceec6cf143990669a04c7df13391d55fb27bd4079d252fca774ba244d8"
 dependencies = [
  "atty",
  "cast",
@@ -199,6 +210,7 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
+ "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -207,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01e15e0ea58e8234f96146b1f91fa9d0e4dd7a38da93ff7a75d42c0b9d3a545"
+checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
 dependencies = [
  "cast",
  "itertools",
@@ -217,12 +229,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
+checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -286,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39858aa5bac06462d4dd4b9164848eb81ffc4aa5c479746393598fd193afa227"
+checksum = "7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484"
 dependencies = [
  "quote",
  "syn",
@@ -314,9 +326,9 @@ checksum = "4c53dc3a653e0f64081026e4bf048d48fec9fce90c66e8326ca7292df0ff2d82"
 
 [[package]]
 name = "either"
-version = "1.5.3"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "env_logger"
@@ -358,10 +370,66 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.1.14"
+name = "filetime"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "fsevent"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -386,10 +454,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "hashbrown"
-version = "0.9.0"
+name = "half"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
+checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
+
+[[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 dependencies = [
  "ahash",
  "rayon",
@@ -406,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.10"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
+checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
 dependencies = [
  "libc",
 ]
@@ -425,10 +499,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "inventory"
-version = "0.1.8"
+name = "inotify"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c68da9c8b1bda33dc6f55b2a9b4f44eca5ba2b2a1a308eab40db9fb7e200cb"
+checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "inventory"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fedd49de24d8c263613701406611410687148ae8c37cd6452650b250f753a0dd"
 dependencies = [
  "ctor",
  "ghost",
@@ -437,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "inventory-impl"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4143007b389ae51577282e3c95cf5a7ae0c9e06cafa927508300ceedcbc0354c"
+checksum = "ddead8880bc50f57fcd3b5869a7f6ff92570bb4e8f6870c22e2483272f2256da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -447,27 +541,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.8.2"
+name = "iovec"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.37"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a27d435371a2fa5b6d2b028a74bbdb1234f308da363226a2854ca3ff8ba7055"
+checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
@@ -475,6 +588,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lexical"
@@ -501,15 +620,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
+checksum = "aa7087f49d294270db4e1928fc110c976cd4b9e5a16348e0a1df09afa99e6c98"
 
 [[package]]
 name = "log"
-version = "0.4.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if",
 ]
@@ -534,11 +653,83 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memoffset"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mio"
+version = "0.6.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
+dependencies = [
+ "cfg-if",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log",
+ "miow",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+dependencies = [
+ "lazycell",
+ "log",
+ "mio",
+ "slab",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
+]
+
+[[package]]
+name = "net2"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "notify"
+version = "4.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80ae4a7688d1fab81c5bf19c64fc8db920be8d519ce6336ed4e7efe024724dbd"
+dependencies = [
+ "bitflags",
+ "filetime",
+ "fsevent",
+ "fsevent-sys",
+ "inotify",
+ "libc",
+ "mio",
+ "mio-extras",
+ "walkdir",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -564,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg",
 ]
@@ -589,9 +780,9 @@ checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
 
 [[package]]
 name = "oorandom"
-version = "11.1.0"
+version = "11.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcec7c9c2a95cacc7cd0ecb89d8a8454eca13906f6deb55258ffff0adeb9405"
+checksum = "a170cebd8021a008ea92e4db85a72f80b35df514ec664b296fdcbb654eac0b2c"
 
 [[package]]
 name = "percent-encoding"
@@ -601,15 +792,15 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pico-args"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1eee8b1f4966c8343d7ca0f5a8452cd35d5610a2e0efbe2a68cae44bef2046"
+checksum = "28b9b4df73455c861d7cbf8be42f01d3b373ed7f02e378d55fa84eafc6f638b1"
 
 [[package]]
 name = "plotters"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3bb8da247d27ae212529352020f3e5ee16e83c0c258061d27b08ab92675eeb"
+checksum = "0d1685fbe7beba33de0330629da9d955ac75bd54f33d7b79f9a895590124f6bb"
 dependencies = [
  "js-sys",
  "num-traits",
@@ -619,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
+checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 
 [[package]]
 name = "proc-macro-error"
@@ -649,15 +840,15 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.16"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
+checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
@@ -746,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd016f0c045ad38b5251be2c9c0ab806917f82da4d36b2a327e5166adad9270"
+checksum = "dcf6960dc9a5b4ee8d3e4c5787b4a112a8818e0290a42ff664ad60692fdf2032"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -758,9 +949,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91739a34c4355b5434ce54c9086c5895604a9c278586d1f1aa95e04f66b525a0"
+checksum = "e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -768,6 +959,12 @@ dependencies = [
  "lazy_static",
  "num_cpus",
 ]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "regex"
@@ -808,7 +1005,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -816,9 +1013,11 @@ name = "rslint_cli"
 version = "0.1.1"
 dependencies = [
  "codespan-reporting",
+ "colored",
  "glob",
  "hashbrown",
  "heck",
+ "notify",
  "rayon",
  "regex",
  "rslint_core",
@@ -840,6 +1039,7 @@ dependencies = [
  "rslint_lexer",
  "rslint_parser",
  "serde",
+ "text-diff",
  "typetag",
 ]
 
@@ -922,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "same-file"
@@ -968,18 +1168,28 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
+checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.115"
+name = "serde_cbor"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
+checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -988,9 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
+checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
 dependencies = [
  "itoa",
  "ryu",
@@ -1004,6 +1214,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
 name = "slice-dst"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "smol_str"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7909a1d8bc166a862124d84fdc11bda0ea4ed3157ccca662296919c2972db1"
+checksum = "6ca0f7ce3a29234210f0f4f0b56f8be2e722488b95cb522077943212da3b32eb"
 
 [[package]]
 name = "spin"
@@ -1097,9 +1313,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc388d94ffabf39b5ed5fadddc40147cb21e605f53db6f8f36a625d27489ac5"
+checksum = "a33f6461027d7f08a13715659b2948e1602c31a3756aeae9378bfe7518c72e82"
 dependencies = [
  "clap",
  "lazy_static",
@@ -1108,9 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2513111825077552a6751dfad9e11ce0fba07d7276a3943a037d7e93e64c5f"
+checksum = "c92e775028122a4b3dd55d58f14fc5120289c69bee99df1d117ae30f84b225c9"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1121,13 +1337,23 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
+checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "term"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2077e54d38055cf1ca0fd7933a2e00cd3ec8f6fed352b2a377f06dcdaaf3281"
+dependencies = [
+ "kernel32-sys",
+ "winapi 0.2.8",
 ]
 
 [[package]]
@@ -1137,6 +1363,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "text-diff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "309238dd66f8bf11a20d015b727b926f294a13fcb8d56770bb984e7a22c43897"
+dependencies = [
+ "getopts",
+ "term",
 ]
 
 [[package]]
@@ -1165,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.17"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca7ec98a72285d12e0febb26f0847b12d54be24577618719df654c66cadab55d"
+checksum = "55b7151c9065e80917fbf285d9a5d1432f60db41d170ccafc749a136b41a93af"
 dependencies = [
  "const_fn",
  "libc",
@@ -1175,14 +1411,14 @@ dependencies = [
  "stdweb",
  "time-macros",
  "version_check",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "time-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9b6e9f095bc105e183e3cd493d72579be3181ad4004fceb01adbe9eecab2d"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
 dependencies = [
  "proc-macro-hack",
  "time-macros-impl",
@@ -1203,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "tinytemplate"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a3c6667d3e65eb1bc3aed6fd14011c6cbc3a0665218ab7f5daf040b9ec371a"
+checksum = "6d3dc76004a03cec1c5932bca4cdc2e39aaa798e3f82363dd94f9adf6098c12f"
 dependencies = [
  "serde",
  "serde_json",
@@ -1228,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "typetag"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9275125decb5d75fe57ebfe92debd119b15757aae27c56d7cb61ecab871960bc"
+checksum = "83b97b107d25d29de6879ac4f676ac5bfea92bdd01f206e995794493f1fc2e32"
 dependencies = [
  "erased-serde",
  "inventory",
@@ -1241,9 +1477,9 @@ dependencies = [
 
 [[package]]
 name = "typetag-impl"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc232cda3b1d82664153e6c95d1071809aa0f1011f306c3d6989f33d8c6ede17"
+checksum = "3f2466fc87b07b800a5060f89ba579d6882f7a03ac21363e4737764aaf9f99f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1276,9 +1512,9 @@ checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
@@ -1300,14 +1536,15 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b770aa61edaa144d3af86a8b0ccbb1bf8ca9dd0c1ac2a17081f35943aae6eb82"
+checksum = "4bbc0597304482f1aa82e296abe382e868c934f0e45ebfe720735990a10e8f5d"
 dependencies = [
  "base64",
  "chunked_transfer",
  "cookie",
  "lazy_static",
+ "log",
  "qstring",
  "rustls",
  "url",
@@ -1328,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "vec_map"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -1345,7 +1582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 dependencies = [
  "same-file",
- "winapi",
+ "winapi 0.3.9",
  "winapi-util",
 ]
 
@@ -1357,9 +1594,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.60"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
+checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1367,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.60"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967d37bf6c16cca2973ca3af071d0a2523392e4a594548155d89a678f4237cd"
+checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1382,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.60"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd151b63e1ea881bb742cd20e1d6127cef28399558f3b5d415289bc41eee3a4"
+checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1392,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.60"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
+checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1405,15 +1642,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.60"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf76fe7d25ac79748a37538b7daeed1c7a6867c92d3245c12c6222e4a20d639"
+checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
 
 [[package]]
 name = "web-sys"
-version = "0.3.37"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6f51648d8c56c366144378a33290049eafdd784071077f6fe37dae64c1c4cb"
+checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1440,13 +1677,25 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1456,11 +1705,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa515c5163a99cc82bab70fd3bfdd36d827be85de63737b40fcef2ce084a436e"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1468,6 +1717,16 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
 
 [[package]]
 name = "xtask"

--- a/rslint_cli/Cargo.toml
+++ b/rslint_cli/Cargo.toml
@@ -21,3 +21,5 @@ hashbrown = { version = "0.9.0", features = ["rayon"] }
 serde = "1.0.115"
 toml = "0.5.6"
 heck = "0.3.1"
+notify = "4.0.15"
+colored = "2.0.0"

--- a/rslint_cli/src/lib.rs
+++ b/rslint_cli/src/lib.rs
@@ -2,6 +2,7 @@ mod cli;
 mod config;
 mod files;
 mod panic_hook;
+mod watch;
 
 pub use self::{cli::ExplanationRunner, config::*, files::*, panic_hook::*};
 pub use rslint_core::{Diagnostic, DiagnosticBuilder, Outcome};
@@ -12,8 +13,10 @@ use codespan_reporting::term::{
     emit,
     termcolor::{self, ColorChoice, StandardStream},
 };
+use colored::*;
 use rayon::prelude::*;
-use rslint_core::{lint_file, CstRuleStore, RuleLevel};
+use rslint_core::{lint_file, CstRuleStore, LintResult, RuleLevel};
+use watch::start_watcher;
 
 pub(crate) const DOCS_LINK_BASE: &str =
     "https://raw.githubusercontent.com/RDambrosio016/RSLint/master/docs/rules";
@@ -26,7 +29,8 @@ pub fn codespan_config() -> Config {
     base
 }
 
-pub fn run(glob: String, verbose: bool) {
+#[allow(unused_must_use)]
+pub fn run(glob: String, verbose: bool, watch: bool) {
     let res = glob::glob(&glob);
     if let Err(err) = res {
         lint_err!("Invalid glob pattern: {}", err);
@@ -79,28 +83,50 @@ pub fn run(glob: String, verbose: bool) {
         .files
         .par_iter()
         .map(|(id, file)| {
-            lint_file(
-                *id,
-                &file.source,
-                file.kind == JsFileKind::Module,
-                &store,
-                verbose,
+            (
+                lint_file(
+                    *id,
+                    &file.source,
+                    file.kind == JsFileKind::Module,
+                    &store,
+                    verbose,
+                ),
+                file,
             )
         })
-        .filter_map(|res| {
+        .filter_map(|(res, file)| {
             if let Err(diagnostic) = res {
                 emit_diagnostic(diagnostic, &walker);
                 None
             } else {
-                res.ok()
+                res.ok().map(|res| (res, file))
             }
         })
         .collect::<Vec<_>>();
 
+    let unzipped_results = results.clone().into_iter().map(|(r, _)| r).collect();
+    print_results(unzipped_results, &walker, config.as_ref());
+
+    if watch {
+        use std::io::Write;
+        use termcolor::{Color, ColorSpec, WriteColor};
+
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)));
+        writeln!(&mut stdout, "\nWatching for file changes...\n");
+        start_watcher(walker.clone(), results, config.as_ref());
+    }
+}
+
+pub(crate) fn print_results(
+    mut results: Vec<LintResult>,
+    walker: &FileWalker,
+    config: Option<&config::Config>,
+) {
     // Map each diagnostic to the correct level according to configured rule level
     for result in results.iter_mut() {
         for (rule_name, diagnostics) in result.rule_diagnostics.iter_mut() {
-            if let Some(conf) = config.as_ref().and_then(|cfg| cfg.rules.as_ref()) {
+            if let Some(conf) = config.and_then(|cfg| cfg.rules.as_ref()) {
                 remap_diagnostics_to_level(diagnostics, conf.rule_level_by_name(rule_name));
             }
         }
@@ -126,7 +152,7 @@ pub fn run(glob: String, verbose: bool) {
             emit(
                 &mut StandardStream::stderr(ColorChoice::Always),
                 &codespan_config(),
-                &walker,
+                walker,
                 diagnostic,
             )
             .expect("Failed to throw diagnostic");
@@ -139,33 +165,15 @@ pub fn run(glob: String, verbose: bool) {
     }
 }
 
+#[allow(unused_must_use)]
 fn output_overall(failures: usize, warnings: usize, successes: usize) {
-    use std::io::Write;
-    use termcolor::{Color, ColorSpec, WriteColor};
-
-    let mut stdout = StandardStream::stdout(ColorChoice::Always);
-    stdout
-        .set_color(ColorSpec::new().set_fg(Some(Color::White)))
-        .unwrap();
-    write!(&mut stdout, "\nOutcome: ").unwrap();
-    stdout
-        .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
-        .unwrap();
-    write!(&mut stdout, "{}", failures).unwrap();
-    stdout.reset().unwrap();
-    write!(&mut stdout, " fail, ").unwrap();
-    stdout
-        .set_color(ColorSpec::new().set_fg(Some(Color::Yellow)))
-        .unwrap();
-    write!(&mut stdout, "{}", warnings).unwrap();
-    stdout.reset().unwrap();
-    write!(&mut stdout, " warn, ").unwrap();
-    stdout
-        .set_color(ColorSpec::new().set_fg(Some(Color::Green)))
-        .unwrap();
-    write!(&mut stdout, "{}", successes).unwrap();
-    stdout.reset().unwrap();
-    writeln!(&mut stdout, " success").unwrap();
+    println!(
+        "{}: {} fail, {} warn, {} success",
+        "Outcome".white(),
+        failures.to_string().red(),
+        warnings.to_string().yellow(),
+        successes.to_string().green()
+    );
 }
 
 /// Remap each error diagnostic to a warning diagnostic based on the rule's level.
@@ -194,6 +202,7 @@ pub fn emit_diagnostic(diagnostic: impl Into<Diagnostic>, walker: &FileWalker) {
     .expect("Failed to throw linter diagnostic");
 }
 
+// TODO: don't use expect because we treat panics as linter bugs
 #[macro_export]
 macro_rules! lint_diagnostic {
     ($severity:ident, $($format_args:tt)*) => {

--- a/rslint_cli/src/main.rs
+++ b/rslint_cli/src/main.rs
@@ -15,6 +15,9 @@ pub(crate) struct Options {
     files: String,
     #[structopt(subcommand)]
     cmd: Option<SubCommand>,
+    /// Watch the linted files for changes and lint them on the fly again
+    #[structopt(short, long)]
+    watch: bool,
 }
 
 #[derive(Debug, StructOpt)]
@@ -32,6 +35,6 @@ fn main() {
     if let Some(SubCommand::Explain { rules }) = opt.cmd {
         ExplanationRunner::new(rules).print();
     } else {
-        rslint_cli::run(opt.files, opt.verbose);
+        rslint_cli::run(opt.files, opt.verbose, opt.watch);
     }
 }

--- a/rslint_cli/src/watch.rs
+++ b/rslint_cli/src/watch.rs
@@ -1,0 +1,80 @@
+//! File watching and incremental relinting facilities.
+
+use crate::*;
+use notify::{watcher, DebouncedEvent, RecursiveMode, Watcher};
+use rslint_core::{incremental::incrementally_relint, LintResult};
+use std::sync::mpsc::channel;
+use std::time::Duration;
+
+pub fn watch<W: Watcher>(walker: &FileWalker, watcher: &mut W) {
+    for file in walker
+        .files
+        .iter()
+        .filter_map(|(_, x)| Some(x).filter(|file| file.path.is_some()))
+    {
+        let _ = watcher.watch(file.path.to_owned().unwrap(), RecursiveMode::NonRecursive);
+    }
+}
+
+#[allow(unused_must_use)]
+pub fn start_watcher(
+    mut walker: FileWalker,
+    mut results: Vec<(LintResult, &JsFile)>,
+    config: Option<&crate::config::Config>,
+) {
+    let (tx, rx) = channel();
+
+    let mut watcher = if let Ok(w) = watcher(tx, Duration::from_millis(100)) {
+        w
+    } else {
+        return lint_err!("failed to create file watcher, exiting");
+    };
+    watch(&walker, &mut watcher);
+
+    loop {
+        let event = rx.recv();
+        if event.is_err() {
+            continue;
+        };
+        match event.unwrap() {
+            DebouncedEvent::Remove(path) | DebouncedEvent::Rename(path, _) => {
+                results.retain(|(_, file)| file.path != Some(path.clone()));
+                watcher.unwatch(path);
+            }
+            // TODO: This wont work for rules which rely on the context of multiple files
+            // and we will have to relint all of the files with all non-CstRule rules
+            DebouncedEvent::Write(path) => {
+                let (old_res, file) = results.iter().find(|(_, file)| {
+                    file.path
+                        .as_ref()
+                        .map_or(false, |x| x.file_name() == path.file_name())
+                }).expect("Tried to get previous result in watcher, but event triggered on an file not included in the linting session");
+                walker.maybe_update_file_src(path.clone());
+
+                let file_id = file.id;
+                let res = incrementally_relint(old_res.clone(), &walker.files[&file.id].source);
+                if let Err(diag) = res {
+                    emit_diagnostic(diag, &walker);
+                    continue;
+                };
+                let new = res.unwrap();
+                let results = results
+                    .clone()
+                    .into_iter()
+                    .map(|(res, _)| res)
+                    .map(|x| {
+                        if x.file_id == file_id {
+                            new.to_owned()
+                        } else {
+                            x
+                        }
+                    })
+                    .collect();
+
+                print_results(results, &walker, config);
+                println!("{}", "watching for changes...\n".white());
+            }
+            _ => {}
+        }
+    }
+}

--- a/rslint_core/Cargo.toml
+++ b/rslint_core/Cargo.toml
@@ -15,3 +15,4 @@ serde = { version = "1.0.115", features = ["derive"] }
 typetag = "0.1.5"
 rayon = "1.4.0"
 dyn-clone = "1.0.2"
+text-diff = "0.4.0"

--- a/rslint_core/src/incremental.rs
+++ b/rslint_core/src/incremental.rs
@@ -1,0 +1,81 @@
+//! Incremental relinting facilities using incremental reparsing.
+
+use crate::*;
+use rslint_parser::{
+    parse_module, parse_text, try_incrementally_reparsing_module,
+    try_incrementally_reparsing_script, SyntaxKind, TextRange, TextSize,
+};
+use text_diff::{diff, Difference};
+use SyntaxKind::*;
+
+/// Convert an old and new string to a vector of indels based on diff
+pub fn diff_to_indels(old: &str, new: &str) -> Vec<Indel> {
+    let (_, diffs) = diff(old, new, " ");
+    let mut indels = Vec::with_capacity(diffs.len() / 2);
+    let mut len: TextSize = 0.into();
+
+    for diff in diffs {
+        match diff {
+            Difference::Add(string) => {
+                let offset = TextSize::from(string.len() as u32);
+                indels.push(Indel::insert(len, string));
+                len += offset;
+            }
+            Difference::Rem(string) => {
+                let offset = TextSize::from(string.len() as u32);
+                indels.push(Indel::delete(TextRange::new(len, len + offset)));
+                len += offset;
+            }
+            Difference::Same(string) => len += TextSize::from(string.len() as u32),
+        }
+    }
+    indels
+}
+
+pub fn incrementally_relint<'a>(
+    old: LintResult<'a>,
+    new: &str,
+) -> Result<LintResult<'a>, Diagnostic> {
+    let old_str = &old.parsed.text().to_string();
+    if old_str == new {
+        return Ok(old);
+    }
+    let indels = diff_to_indels(&old.parsed.text().to_string(), new);
+    let mut reparsed = None;
+
+    for indel in indels {
+        let reparse = if old.parsed.kind() == SCRIPT {
+            try_incrementally_reparsing_script(
+                old.parsed.clone(),
+                old.parser_diagnostics.clone(),
+                &indel,
+                old.file_id,
+            )
+            .map(|p| (p.syntax(), p.errors().to_owned()))
+        } else {
+            try_incrementally_reparsing_module(
+                old.parsed.clone(),
+                old.parser_diagnostics.clone(),
+                &indel,
+                old.file_id,
+            )
+            .map(|p| (p.syntax(), p.errors().to_owned()))
+        };
+        // if reparsing failed then there is no point in trying to reparse again because
+        // the alternative to reparsing failure is parsing the whole text
+        // so at that point reparsing has no value
+        if reparse.is_none() {
+            reparsed = if old.parsed.kind() == SCRIPT {
+                let res = parse_text(new, old.file_id);
+                Some((res.syntax(), res.errors().to_owned()))
+            } else {
+                let res = parse_module(new, old.file_id);
+                Some((res.syntax(), res.errors().to_owned()))
+            };
+            break;
+        }
+        reparsed = reparse;
+    }
+    let (node, errors) = reparsed.unwrap();
+    lint_file_inner(node, errors, old.file_id, old.store, old.verbose)
+}

--- a/rslint_core/src/lib.rs
+++ b/rslint_core/src/lib.rs
@@ -1,3 +1,31 @@
+//! The core runner for RSLint responsible for the bulk of the linter's work.
+//!
+//! The crate is not RSLint-specific and can be used from any project. The runner is responsible
+//! for taking a list of rules, and source code and running the linter on it. It is important to decouple
+//! the CLI work and the low level linting work from eachother to be able to reuse the linter facilities.
+//! Therefore, the core runner should never do anything `rslint_cli`-specific.
+//!
+//! The structure at the core of the crate is the [`CstRule`] and [`Rule`] traits.
+//! CST rules run on a single file and its concrete syntax tree produced by [`rslint_parser`].
+//! The rules have a couple of restrictions for clarity and speed, these include:
+//! - all cst rules must be [`Send`](std::marker::Send) and [`Sync`](std::marker::Sync) so they can be run in parallel
+//! - rules may never rely on the results of other rules, this is impossible because rules are run in parallel
+//! - rules should never make any network or file requests
+//!
+//! ## Using the runner
+//!
+//! To run the runner you must first create a [`CstRuleStore`], which is the structure used for storing what rules
+//! to run. Then you can use [`lint_file`].
+//!
+//! ## Running a single rule
+//!
+//! To run a single rule you can find the rule you want in the `groups` module and submodules within. Then
+//! to run a rule in full on a syntax tree you can use [`run_rule`].
+//!
+//! Rules can also be run on individual nodes using the functions on [`CstRule`].
+//! ⚠️ note however that many rules rely on checking tokens or the root and running on single nodes
+//! may yield incorrect results, you should only do this if you know about the rule's implementation.
+
 mod diagnostic;
 mod rule;
 mod store;
@@ -5,6 +33,7 @@ mod testing;
 
 pub mod directives;
 pub mod groups;
+pub mod incremental;
 pub mod rule_prelude;
 pub mod util;
 
@@ -14,6 +43,7 @@ pub use self::{
     store::CstRuleStore,
 };
 pub use codespan_reporting::diagnostic::{Label, Severity};
+pub use rslint_parser::Indel;
 
 use crate::directives::{apply_top_level_directives, skip_node, Directive, DirectiveParser};
 use dyn_clone::clone_box;
@@ -25,12 +55,16 @@ use std::collections::HashMap;
 pub type Diagnostic = codespan_reporting::diagnostic::Diagnostic<usize>;
 
 /// The result of linting a file.
-#[derive(Debug)]
+// TODO: A lot of this stuff can be shoved behind a "linter options" struct
+#[derive(Debug, Clone)]
 pub struct LintResult<'s> {
     pub parser_diagnostics: Vec<Diagnostic>,
     pub store: &'s CstRuleStore,
     pub rule_diagnostics: HashMap<&'static str, Vec<Diagnostic>>,
     pub directive_diagnostics: Vec<Diagnostic>,
+    pub parsed: SyntaxNode,
+    pub file_id: usize,
+    pub verbose: bool,
 }
 
 impl LintResult<'_> {
@@ -64,10 +98,25 @@ pub fn lint_file(
         let parse = parse_text(file_source.as_ref(), file_id);
         (parse.errors().to_owned(), parse.green())
     };
+    lint_file_inner(
+        SyntaxNode::new_root(green),
+        parser_diagnostics,
+        file_id,
+        store,
+        verbose,
+    )
+}
 
+/// used by lint_file and incrementally_relint to not duplicate code
+pub(crate) fn lint_file_inner(
+    node: SyntaxNode,
+    parser_diagnostics: Vec<Diagnostic>,
+    file_id: usize,
+    store: &CstRuleStore,
+    verbose: bool,
+) -> Result<LintResult, Diagnostic> {
     let mut new_store = store.clone();
-    let results = DirectiveParser::new(SyntaxNode::new_root(green.clone()), file_id, store)
-        .get_file_directives()?;
+    let results = DirectiveParser::new(node.clone(), file_id, store).get_file_directives()?;
     let mut directive_diagnostics = vec![];
 
     let directives = results
@@ -89,11 +138,9 @@ pub fn lint_file(
         .rules
         .par_iter()
         .map(|rule| {
-            let root = SyntaxNode::new_root(green.clone());
-
             (
                 rule.name(),
-                run_rule(&**rule, file_id, root, verbose, &directives),
+                run_rule(&**rule, file_id, node.clone(), verbose, &directives),
             )
         })
         .collect();
@@ -103,6 +150,9 @@ pub fn lint_file(
         store,
         rule_diagnostics,
         directive_diagnostics,
+        parsed: node,
+        file_id,
+        verbose,
     })
 }
 

--- a/rslint_errors/Cargo.toml
+++ b/rslint_errors/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rslint_errors"
+version = "0.1.0"
+authors = ["RDambrosio016 <rdambrosio016@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+termcolor = "1.1.0"

--- a/rslint_parser/src/incremental.rs
+++ b/rslint_parser/src/incremental.rs
@@ -1,0 +1,279 @@
+use crate::syntax::{decl::*, expr::*, pat::object_binding_pattern, stmt::*};
+use crate::{SyntaxKind::*, *};
+use rowan::GreenToken;
+
+/// insert-delete, a single change to text which does not overlap with
+/// other indels
+#[derive(Debug, Clone)]
+pub struct Indel {
+    pub insert: String,
+    pub delete: TextRange,
+}
+
+impl Indel {
+    pub fn insert(offset: TextSize, text: String) -> Indel {
+        Indel::replace(TextRange::empty(offset), text)
+    }
+    pub fn delete(range: TextRange) -> Indel {
+        Indel::replace(range, String::new())
+    }
+    pub fn replace(range: TextRange, replace_with: String) -> Indel {
+        Indel {
+            delete: range,
+            insert: replace_with,
+        }
+    }
+
+    pub fn apply(&self, text: &mut String) {
+        let start: usize = self.delete.start().into();
+        let end: usize = self.delete.end().into();
+        text.replace_range(start..end, &self.insert);
+    }
+}
+
+pub(crate) fn incremental_reparse(
+    node: &SyntaxNode,
+    edit: &Indel,
+    errors: Vec<ParserError>,
+    file_id: usize,
+) -> Option<(GreenNode, Vec<ParserError>, TextRange)> {
+    if let Some((green, new_errors, old_range)) = reparse_token(node, &edit, file_id) {
+        return Some((
+            green,
+            merge_errors(errors, new_errors, old_range, edit),
+            old_range,
+        ));
+    }
+
+    if let Some((green, new_errors, old_range)) = reparse_block(node, &edit, file_id) {
+        return Some((
+            green,
+            merge_errors(errors, new_errors, old_range, edit),
+            old_range,
+        ));
+    }
+    None
+}
+
+fn merge_errors(
+    mut old_errors: Vec<ParserError>,
+    new_errors: Vec<ParserError>,
+    range_before_reparse: TextRange,
+    edit: &Indel,
+) -> Vec<ParserError> {
+    for old_err in old_errors.iter_mut() {
+        let inserted_len = TextSize::of(&edit.insert);
+        for label in old_err.labels.iter_mut() {
+            let old_range = TextRange::new(
+                (label.range.start as u32).into(),
+                (label.range.end as u32).into(),
+            );
+            if old_range.end() >= range_before_reparse.start() {
+                label.range = ((old_range + inserted_len) - edit.delete.len()).into();
+            }
+        }
+    }
+
+    old_errors.extend(new_errors.into_iter().map(|mut new_err| {
+        for label in new_err.labels.iter_mut() {
+            let old_range = TextRange::new(
+                (label.range.start as u32).into(),
+                (label.range.end as u32).into(),
+            );
+            label.range = (old_range + range_before_reparse.start()).into();
+        }
+        new_err
+    }));
+    old_errors
+}
+
+fn reparse_token<'node>(
+    root: &'node SyntaxNode,
+    edit: &Indel,
+    file_id: usize,
+) -> Option<(GreenNode, Vec<ParserError>, TextRange)> {
+    let prev_token = root.covering_element(edit.delete).as_token()?.clone();
+    let prev_token_kind = prev_token.kind();
+    match prev_token_kind {
+        WHITESPACE | COMMENT | IDENT | STRING | TEMPLATE_CHUNK => {
+            if prev_token_kind == WHITESPACE || prev_token_kind == COMMENT {
+                // removing a new line may extend the previous token
+                let deleted_range = edit.delete - prev_token.text_range().start();
+                if util::contains_js_linebreak(&prev_token.text()[deleted_range]) {
+                    return None;
+                }
+            }
+
+            let mut new_text = get_text_after_edit(prev_token.clone().into(), &edit);
+            let (new_token_kind, new_err) = lex_single_syntax_kind(&new_text, file_id)?;
+
+            if new_token_kind != prev_token_kind
+                || (new_token_kind == IDENT && is_contextual_kw(&new_text))
+            {
+                return None;
+            }
+
+            // Check that edited token is not a part of the bigger token.
+            if let Some(next_char) = root.text().char_at(prev_token.text_range().end()) {
+                new_text.push(next_char);
+                let token_with_next_char = lex_single_syntax_kind(&new_text, file_id);
+                if let Some((_kind, _error)) = token_with_next_char {
+                    return None;
+                }
+                new_text.pop();
+            }
+
+            let new_token =
+                GreenToken::new(rowan::SyntaxKind(prev_token_kind.into()), new_text.into());
+            Some((
+                prev_token.replace_with(new_token),
+                new_err.into_iter().collect(),
+                prev_token.text_range(),
+            ))
+        }
+        _ => None,
+    }
+}
+
+fn reparse_block<'node>(
+    root: &'node SyntaxNode,
+    edit: &Indel,
+    file_id: usize,
+) -> Option<(GreenNode, Vec<ParserError>, TextRange)> {
+    let (node, function) = find_reparsable_node(root, edit.delete)?;
+    let text = get_text_after_edit(node.clone().into(), edit);
+
+    let (tokens, new_lexer_errors) = tokenize(&text, file_id);
+    let vec = tokens
+        .iter()
+        .map(|t| t.kind)
+        .filter(|k| !k.is_trivia())
+        .collect::<Vec<_>>();
+
+    // skip eof
+    if !is_balanced(&vec[..vec.len() - 1]) {
+        return None;
+    }
+    let token_source = TokenSource::new(&text, &tokens);
+    let mut tree_sink = LosslessTreeSink::new(&text, &tokens);
+    reparse(function, token_source, &mut tree_sink, file_id);
+
+    let (green, mut new_parser_errors) = tree_sink.finish();
+    new_parser_errors.extend(new_lexer_errors);
+
+    Some((
+        node.replace_with(green),
+        new_parser_errors,
+        node.text_range(),
+    ))
+}
+
+#[allow(clippy::type_complexity)]
+fn find_reparsable_node(
+    node: &SyntaxNode,
+    range: TextRange,
+) -> Option<(SyntaxNode, fn(&mut Parser) -> CompletedMarker)> {
+    let node = node.covering_element(range);
+
+    let mut ancestors = match node {
+        NodeOrToken::Token(it) => it.parent().ancestors(),
+        NodeOrToken::Node(it) => it.ancestors(),
+    };
+    ancestors.find_map(|node| {
+        let parent = node.parent().map(|it| it.kind());
+        let function = get_reparser_fn(node.kind(), parent)?;
+        Some((node, function))
+    })
+}
+
+fn is_balanced(tokens: &[SyntaxKind]) -> bool {
+    if tokens.is_empty()
+        || tokens.first().unwrap() != &T!['{']
+        || tokens.last().unwrap() != &T!['}']
+    {
+        return false;
+    }
+    let mut balance = 0usize;
+    for t in &tokens[1..tokens.len() - 1] {
+        match t {
+            T!['{'] => balance += 1,
+            T!['}'] => {
+                balance = match balance.checked_sub(1) {
+                    Some(b) => b,
+                    None => return false,
+                }
+            }
+            _ => (),
+        }
+    }
+    balance == 0
+}
+
+fn lex_single_syntax_kind(
+    string: &str,
+    file_id: usize,
+) -> Option<(SyntaxKind, Option<ParserError>)> {
+    rslint_lexer::Lexer::from_str(string, file_id)
+        .next()
+        .map(|(t, e)| (t.kind, e))
+}
+
+fn get_text_after_edit(element: SyntaxElement, edit: &Indel) -> String {
+    let edit = Indel::replace(
+        edit.delete - element.text_range().start(),
+        edit.insert.clone(),
+    );
+
+    let mut text = match element {
+        NodeOrToken::Token(token) => token.text().to_string(),
+        NodeOrToken::Node(node) => node.text().to_string(),
+    };
+    edit.apply(&mut text);
+    text
+}
+
+fn is_contextual_kw(string: &str) -> bool {
+    matches!(string, "await" | "async" | "yield")
+}
+
+fn block_stmt_reparse(p: &mut Parser) -> CompletedMarker {
+    block_stmt(p, false, None)
+}
+
+fn block_stmt_reparse_fn(p: &mut Parser) -> CompletedMarker {
+    block_stmt(p, true, None)
+}
+
+// TODO: switch stmt, import, and export reparsing
+fn get_reparser_fn(
+    node: SyntaxKind,
+    parent: Option<SyntaxKind>,
+) -> Option<fn(&mut Parser) -> CompletedMarker> {
+    let res = match node {
+        BLOCK_STMT => {
+            if let Some(FN_DECL) | Some(FN_EXPR) = parent {
+                block_stmt_reparse_fn
+            } else {
+                block_stmt_reparse
+            }
+        }
+        OBJECT_EXPR => object_expr,
+        OBJECT_PATTERN => object_binding_pattern,
+        CLASS_BODY => class_body,
+        _ => return None,
+    };
+
+    Some(res)
+}
+
+fn reparse(
+    function: fn(&mut Parser) -> CompletedMarker,
+    token_source: TokenSource,
+    sink: &mut dyn TreeSink,
+    file_id: usize,
+) {
+    let mut p = Parser::new(token_source, file_id);
+    function(&mut p);
+    let events = p.finish();
+    process(sink, events);
+}

--- a/rslint_parser/src/incremental.rs
+++ b/rslint_parser/src/incremental.rs
@@ -4,7 +4,7 @@ use rslint_rowan::GreenToken;
 
 /// insert-delete, a single change to text which does not overlap with
 /// other indels
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Indel {
     pub insert: String,
     pub delete: TextRange,

--- a/rslint_parser/src/incremental.rs
+++ b/rslint_parser/src/incremental.rs
@@ -1,6 +1,6 @@
 use crate::syntax::{decl::*, expr::*, pat::object_binding_pattern, stmt::*};
 use crate::{SyntaxKind::*, *};
-use rowan::GreenToken;
+use rslint_rowan::GreenToken;
 
 /// insert-delete, a single change to text which does not overlap with
 /// other indels
@@ -123,8 +123,10 @@ fn reparse_token<'node>(
                 new_text.pop();
             }
 
-            let new_token =
-                GreenToken::new(rowan::SyntaxKind(prev_token_kind.into()), new_text.into());
+            let new_token = GreenToken::new(
+                rslint_rowan::SyntaxKind(prev_token_kind.into()),
+                new_text.into(),
+            );
             Some((
                 prev_token.replace_with(new_token),
                 new_err.into_iter().collect(),

--- a/rslint_parser/src/lib.rs
+++ b/rslint_parser/src/lib.rs
@@ -22,6 +22,7 @@
 //! - Very easy tree traversal through [`SyntaxNode`](rslint_rowan::SyntaxNode).
 //! - Descriptive errors with multiple labels and notes.
 //! - Very cheap cloning, cloning an ast node or syntax node is the cost of adding a reference to an Rc.
+//! - Cheap incremental reparsing of changed text.
 //!
 //! The crate further includes utilities such as:
 //! - ANSI syntax highlighting of nodes (through [`util`]) or text through [`rslint_lexer`].
@@ -60,6 +61,7 @@ mod parser;
 mod token_set;
 mod diagnostics;
 mod event;
+mod incremental;
 mod lossless_tree_sink;
 mod lossy_tree_sink;
 mod numbers;
@@ -80,6 +82,7 @@ pub use crate::{
     ast::{AstNode, AstToken},
     diagnostics::ErrorBuilder,
     event::{process, Event},
+    incremental::Indel,
     lossless_tree_sink::LosslessTreeSink,
     lossy_tree_sink::LossyTreeSink,
     numbers::{BigInt, JsNum},

--- a/rslint_parser/src/parse.rs
+++ b/rslint_parser/src/parse.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     ast::{Expr, Module, Script},
+    incremental::{incremental_reparse, Indel},
     AstNode, Event, GreenNode, LosslessTreeSink, LossyTreeSink, ParserError, SyntaxNode,
     TokenSource,
 };
@@ -252,4 +253,32 @@ pub fn parse_expr(text: &str, file_id: usize) -> Parse<Expr> {
     let (green, parse_errors) = tree_sink.finish();
     errors.extend(parse_errors);
     Parse::new(green, errors)
+}
+
+pub fn try_incrementally_reparsing_script(
+    old: SyntaxNode,
+    errors: Vec<ParserError>,
+    change: &Indel,
+    file_id: usize,
+) -> Option<Parse<Script>> {
+    let res = incremental_reparse(&old, change, errors, file_id);
+    if let Some((green, errors, _)) = res {
+        Some(Parse::new(green, errors))
+    } else {
+        None
+    }
+}
+
+pub fn try_incrementally_reparsing_module(
+    old: SyntaxNode,
+    errors: Vec<ParserError>,
+    change: &Indel,
+    file_id: usize,
+) -> Option<Parse<Module>> {
+    let res = incremental_reparse(&old, change, errors, file_id);
+    if let Some((green, errors, _)) = res {
+        Some(Parse::new(green, errors))
+    } else {
+        None
+    }
 }

--- a/rslint_parser/src/syntax/decl.rs
+++ b/rslint_parser/src/syntax/decl.rs
@@ -133,7 +133,7 @@ pub fn class_decl(p: &mut Parser, expr: bool) -> CompletedMarker {
     m.complete(&mut *guard, CLASS_DECL)
 }
 
-fn class_body(p: &mut Parser) -> CompletedMarker {
+pub(crate) fn class_body(p: &mut Parser) -> CompletedMarker {
     let m = p.start();
     p.expect(T!['{']);
 

--- a/rslint_parser/src/syntax/program.rs
+++ b/rslint_parser/src/syntax/program.rs
@@ -53,7 +53,7 @@ pub fn import_decl(p: &mut Parser) -> CompletedMarker {
             from_clause(p);
         }
         T!['{'] => {
-            named_list(p, None).complete(p, NAMED_IMPORTS);
+            named_imports(p);
             from_clause(p);
         }
         T![ident] | T![await] | T![yield] => {
@@ -77,6 +77,10 @@ pub fn import_decl(p: &mut Parser) -> CompletedMarker {
 
     p.expect(T![;]);
     m.complete(p, IMPORT_DECL)
+}
+
+pub(crate) fn named_imports(p: &mut Parser) -> CompletedMarker {
+    named_list(p, None).complete(p, NAMED_IMPORTS)
 }
 
 fn wildcard(p: &mut Parser, m: impl Into<Option<Marker>>) -> Marker {


### PR DESCRIPTION
This PR adds incremental relinting, incremental reparsing, and file watching.

Incremental reparsing is calculating what changes occurred in the file and only parsing the least amount of text we need. This is achieved through two methods:

- If the change only affects a single token and its not contextual we lex the token and replace it in the tree
- Otherwise we look for the nearest block (block stmt, class body, etc) to reparse.

I am not certain of its stability yet and i am sure there are some weird cases in which it fails or parses incorrectly which needs to be sorted out. The reparser needs some tests too.

To test this simply clone the branch and then use `cargo run -- ./glob/pattern -w` which will watch the already linted files for changes and try to lint them again with incremental reparsing.

I would also like to add an `#[incremental_safe]` macro which marks if a rule relies on a single node and only has to be run on the specific nodes that have been changed, this is not the case for most rules however.