### PR TITLE
Throw an error if no matching files are found

### DIFF
--- a/rslint_cli/src/lib.rs
+++ b/rslint_cli/src/lib.rs
@@ -70,7 +70,7 @@ pub fn run(glob: String, verbose: bool) {
         CstRuleStore::new().builtins()
     };
 
-    if walker.files.len() == 0 {
+    if walker.files.is_empty() {
         lint_err!("No matching files found");
         return;
     }

--- a/rslint_cli/src/lib.rs
+++ b/rslint_cli/src/lib.rs
@@ -70,6 +70,11 @@ pub fn run(glob: String, verbose: bool) {
         CstRuleStore::new().builtins()
     };
 
+    if walker.files.len() == 0 {
+        lint_err!("No matching files found");
+        return;
+    }
+
     let mut results = walker
         .files
         .par_iter()


### PR DESCRIPTION
Fixes #19 by checking the number of matching files found and throwing an error if it's zero.