### PR TITLE
Feat: add `no-confusing-arrow` rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,6 +1099,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rowan"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e081ed6eacce09e243b619ab90f069c27b0cff8a6d0eb8ad2ec935b65853798"
+dependencies = [
+ "rustc-hash",
+ "smol_str",
+ "text-size",
+ "thin-dst",
+]
+
+[[package]]
 name = "rslint_cli"
 version = "0.1.2"
 dependencies = [
@@ -1199,6 +1211,13 @@ name = "rslint_syntax"
 version = "0.1.2"
 dependencies = [
  "rslint_rowan",
+]
+
+[[package]]
+name = "rslint_text_edit"
+version = "0.1.0"
+dependencies = [
+ "rowan",
 ]
 
 [[package]]
@@ -1491,6 +1510,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "thin-dst"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c46be180f1af9673ebb27bc1235396f61ef6965b3fe0dbb2e624deb604f0e"
 
 [[package]]
 name = "thiserror"

--- a/crates/rslint_core/CHANGELOG.md
+++ b/crates/rslint_core/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 - Added "no-new-symbol" rule
+- Added "no-confusing-arrow" rule
 
 ### Added
 - Added more documentation for some methods and structs

--- a/crates/rslint_core/src/groups/errors/mod.rs
+++ b/crates/rslint_core/src/groups/errors/mod.rs
@@ -31,4 +31,5 @@ group! {
     no_setter_return::NoSetterReturn,
     valid_typeof::ValidTypeof,
     no_extra_boolean_cast::NoExtraBooleanCast,
+    no_confusing_arrow::NoConfusingArrow,
 }

--- a/crates/rslint_core/src/groups/errors/no_confusing_arrow.rs
+++ b/crates/rslint_core/src/groups/errors/no_confusing_arrow.rs
@@ -32,6 +32,7 @@ declare_lint! {
     errors,
     "no-confusing-arrow",
     /// Relaxes the rule and accepts parenthesis as a valid "confusion-preventing" syntax.
+    /// `true` by default.
     pub allow_parens: bool
 }
 

--- a/crates/rslint_core/src/groups/errors/no_confusing_arrow.rs
+++ b/crates/rslint_core/src/groups/errors/no_confusing_arrow.rs
@@ -1,0 +1,115 @@
+use crate::rule_prelude::*;
+use ast::{ArrowExpr, Expr};
+
+declare_lint! {
+    /**
+    Disallow arrow functions where they could be confused with comparisons.
+
+    Arrow functions (`=>`) are similar in syntax to some comparison operators (`>`, `<`, `<=`, and `>=`).
+    This rule warns against using the arrow function syntax in places where it could be confused with
+    a comparison operator
+
+    Here's an example where the usage of `=>` could be confusing:
+
+    ```js
+    // The intent is not clear
+    var x = a => 1 ? 2 : 3;
+    // Did the author mean this
+    var x = function (a) { return 1 ? 2 : 3 };
+    // Or this
+    var x = a <= 1 ? 2 : 3;
+    ```
+
+    ## Incorrect Code Examples
+
+    ```js
+    var x = a => 1 ? 2 : 3;
+    var x = (a) => 1 ? 2 : 3;
+    ```
+    */
+    #[serde(default)]
+    NoConfusingArrow,
+    errors,
+    "no-confusing-arrow",
+    /// Relaxes the rule and accepts parenthesis as a valid "confusion-preventing" syntax.
+    pub allow_parens: bool
+}
+
+impl Default for NoConfusingArrow {
+    fn default() -> Self {
+        Self { allow_parens: true }
+    }
+}
+
+#[typetag::serde]
+impl CstRule for NoConfusingArrow {
+    fn check_node(&self, node: &SyntaxNode, ctx: &mut RuleCtx) -> Option<()> {
+        let function_stmt = node.try_to::<ArrowExpr>()?;
+        let expr = Expr::cast(function_stmt.body()?.syntax().to_owned())?;
+
+        if is_conditional(&expr) && !(self.allow_parens && is_parenthesised(&expr)) {
+            let diagnostic = ctx
+                .err(
+                    self.name(),
+                    "Arrow function used ambiguously with a conditional expression",
+                )
+                .primary(
+                    function_stmt.syntax(),
+                    "it could be confused with a comparison operator",
+                );
+
+            ctx.add_err(diagnostic);
+        }
+
+        None
+    }
+}
+
+fn is_conditional(expr: &Expr) -> bool {
+    match expr {
+        Expr::CondExpr(_) => true,
+        Expr::GroupingExpr(group) => group.inner().map_or(false, |e| is_conditional(&e)),
+        _ => false,
+    }
+}
+
+fn is_parenthesised(expr: &Expr) -> bool {
+    match expr {
+        Expr::GroupingExpr(_) => true,
+        _ => false,
+    }
+}
+
+rule_tests! {
+    NoConfusingArrow::default(),
+    err: {
+        "a => 1 ? 2 : 3",
+        "var x = a => 1 ? 2 : 3",
+        "var x = (a) => 1 ? 2 : 3",
+    },
+    ok: {
+        "a => { return 1 ? 2 : 3; }",
+        "var x = a => { return 1 ? 2 : 3; }",
+        "var x = (a) => { return 1 ? 2 : 3; }",
+        "var x = a => (1 ? 2 : 3)",
+    }
+}
+
+rule_tests! {
+    allow_parens_false_valid,
+    allow_parens_false_invalid,
+    NoConfusingArrow {
+        allow_parens: false,
+    },
+    err: {
+        "a => 1 ? 2 : 3",
+        "var x = a => 1 ? 2 : 3",
+        "var x = (a) => 1 ? 2 : 3",
+        "var x = a => (1 ? 2 : 3)",
+    },
+    ok: {
+        "a => { return 1 ? 2 : 3; }",
+        "var x = a => { return 1 ? 2 : 3; }",
+        "var x = (a) => { return 1 ? 2 : 3; }",
+    }
+}

--- a/crates/rslint_core/src/groups/errors/no_confusing_arrow.rs
+++ b/crates/rslint_core/src/groups/errors/no_confusing_arrow.rs
@@ -52,7 +52,7 @@ impl CstRule for NoConfusingArrow {
             let diagnostic = ctx
                 .err(
                     self.name(),
-                    "Arrow function used ambiguously with a conditional expression",
+                    "arrow function in ternary expression could be mistaken for a comparison",
                 )
                 .primary(
                     function_stmt.syntax(),

--- a/crates/rslint_core/src/groups/errors/no_confusing_arrow.rs
+++ b/crates/rslint_core/src/groups/errors/no_confusing_arrow.rs
@@ -46,7 +46,7 @@ impl Default for NoConfusingArrow {
 impl CstRule for NoConfusingArrow {
     fn check_node(&self, node: &SyntaxNode, ctx: &mut RuleCtx) -> Option<()> {
         let function_stmt = node.try_to::<ArrowExpr>()?;
-        let expr = Expr::cast(function_stmt.body()?.syntax().to_owned())?;
+        let expr = function_stmt.body()?.syntax().try_to::<Expr>()?;
 
         if is_conditional(&expr) && !(self.allow_parens && is_parenthesised(&expr)) {
             let diagnostic = ctx

--- a/crates/rslint_core/src/groups/errors/no_confusing_arrow.rs
+++ b/crates/rslint_core/src/groups/errors/no_confusing_arrow.rs
@@ -74,10 +74,7 @@ fn is_conditional(expr: &Expr) -> bool {
 }
 
 fn is_parenthesised(expr: &Expr) -> bool {
-    match expr {
-        Expr::GroupingExpr(_) => true,
-        _ => false,
-    }
+    matches!(expr, Expr::GroupingExpr(_))
 }
 
 rule_tests! {

--- a/crates/rslint_core/src/groups/errors/no_confusing_arrow.rs
+++ b/crates/rslint_core/src/groups/errors/no_confusing_arrow.rs
@@ -17,7 +17,7 @@ declare_lint! {
     // Did the author mean this
     var x = function (a) { return 1 ? 2 : 3 };
     // Or this
-    var x = a <= 1 ? 2 : 3;
+    var x = a >= 1 ? 2 : 3;
     ```
 
     ## Incorrect Code Examples

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -16,6 +16,7 @@
     - [no-await-in-loop](rules/errors/no-await-in-loop.md)
     - [no-compare-neg-zero](rules/errors/no-compare-neg-zero.md)
     - [no-cond-assign](rules/errors/no-cond-assign.md)
+    - [no-confusing-arrow](rules/errors/no-confusing-arrow.md)
     - [no-constant-condition](rules/errors/no-constant-condition.md)
     - [no-debugger](rules/errors/no-debugger.md)
     - [no-dupe-keys](rules/errors/no-dupe-keys.md)

--- a/docs/rules/errors/README.md
+++ b/docs/rules/errors/README.md
@@ -15,6 +15,7 @@ unexpected behavior.
 | [no-await-in-loop](./no-await-in-loop.md) | Disallow await inside of loops. |
 | [no-compare-neg-zero](./no-compare-neg-zero.md) | Disallow comparison against `-0` which yields unexpected behavior. |
 | [no-cond-assign](./no-cond-assign.md) | Forbid the use of assignment expressions in conditions which may yield unwanted behavior. |
+| [no-confusing-arrow](./no-confusing-arrow.md) | Disallow arrow functions where they could be confused with comparisons. |
 | [no-constant-condition](./no-constant-condition.md) | Disallow constant conditions which always yield one result. |
 | [no-debugger](./no-debugger.md) | Disallow the use of debugger statements. |
 | [no-dupe-keys](./no-dupe-keys.md) | Disallow duplicate keys in object literals. |

--- a/docs/rules/errors/no-confusing-arrow.md
+++ b/docs/rules/errors/no-confusing-arrow.md
@@ -30,7 +30,7 @@ var x = (a) => 1 ? 2 : 3;
 ## Config
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `allowParens` | bool |  Relaxes the rule and accepts parenthesis as a valid "confusion-preventing" syntax. |
+| `allowParens` | bool |  Relaxes the rule and accepts parenthesis as a valid "confusion-preventing" syntax.<br>`true` by default. |
 
 <details>
  <summary> More incorrect examples </summary>

--- a/docs/rules/errors/no-confusing-arrow.md
+++ b/docs/rules/errors/no-confusing-arrow.md
@@ -1,0 +1,70 @@
+<!--
+ generated docs file, do not edit by hand, see xtask/docgen 
+-->
+# no-confusing-arrow
+
+Disallow arrow functions where they could be confused with comparisons.
+
+Arrow functions (`=>`) are similar in syntax to some comparison operators (`>`, `<`, `<=`, and `>=`).
+This rule warns against using the arrow function syntax in places where it could be confused with
+a comparison operator
+
+Here's an example where the usage of `=>` could be confusing:
+
+```js
+// The intent is not clear
+var x = a => 1 ? 2 : 3;
+// Did the author mean this
+var x = function (a) { return 1 ? 2 : 3 };
+// Or this
+var x = a <= 1 ? 2 : 3;
+```
+
+## Incorrect Code Examples
+
+```js
+var x = a => 1 ? 2 : 3;
+var x = (a) => 1 ? 2 : 3;
+```
+
+## Config
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `allowParens` | bool |  Relaxes the rule and accepts parenthesis as a valid "confusion-preventing" syntax. |
+
+<details>
+ <summary> More incorrect examples </summary>
+
+```js
+a => 1 ? 2 : 3
+```
+
+```js
+var x = a => 1 ? 2 : 3
+```
+
+```js
+var x = (a) => 1 ? 2 : 3
+```
+</details><br>
+<details>
+ <summary> More correct examples </summary>
+
+```js
+a => { return 1 ? 2 : 3; }
+```
+
+```js
+var x = a => { return 1 ? 2 : 3; }
+```
+
+```js
+var x = (a) => { return 1 ? 2 : 3; }
+```
+
+```js
+var x = a => (1 ? 2 : 3)
+```
+</details>
+
+[Source](https://github.com/RDambrosio016/RSLint/tree/master/crates/rslint_core/src/groups/errors/no_confusing_arrow.rs)

--- a/docs/rules/errors/no-confusing-arrow.md
+++ b/docs/rules/errors/no-confusing-arrow.md
@@ -17,7 +17,7 @@ var x = a => 1 ? 2 : 3;
 // Did the author mean this
 var x = function (a) { return 1 ? 2 : 3 };
 // Or this
-var x = a <= 1 ? 2 : 3;
+var x = a >= 1 ? 2 : 3;
 ```
 
 ## Incorrect Code Examples


### PR DESCRIPTION
A part of [Implement error rules from eslint/ECMAScript 6](https://github.com/RDambrosio016/RSLint/issues/53)

In this PR, I added the `no-confusing-arrow` rule.

```
error[no-confusing-arrow]: Arrow function used ambiguously with a conditional expression
  ┌─ foo.js:1:1
  │
1 │ a => b ? 2 : 3;
  │ ^^^^^^^^^^^^^^ it could be confused with a comparison operator
```