### PR TITLE
Improve config error reporting

### DIFF
--- a/crates/rslint_cli/src/config.rs
+++ b/crates/rslint_cli/src/config.rs
@@ -6,6 +6,10 @@ use rslint_core::{
     get_group_rules_by_name, get_rule_by_name, get_rule_suggestion, CstRule, CstRuleStore,
     RuleLevel,
 };
+use rslint_errors::{
+    file::{Files, SimpleFile},
+    Diagnostic,
+};
 use serde::de::{
     value::MapAccessDeserializer, DeserializeSeed, Error, IntoDeserializer, MapAccess, Visitor,
 };
@@ -43,11 +47,38 @@ impl Config {
     /// Search for a config file in the current directory,
     /// return None if there is no config or if its unreadable.
     /// This returns a thread handle which was spawned for multithreaded IO.
-    pub fn new_threaded() -> JoinHandle<Option<Result<Self, toml::de::Error>>> {
+    pub fn new_threaded() -> JoinHandle<Option<Self>> {
         thread::spawn(|| {
-            let cur = current_dir().ok()?;
-            let file = cur.join(CONFIG_NAME);
-            Some(from_str(&read_to_string(file).ok()?))
+            let (source, path) = match current_dir()
+                .map(|path| path.join(CONFIG_NAME))
+                .and_then(|path| Ok((read_to_string(&path)?, path)))
+            {
+                Ok(val) => val,
+                Err(err) => {
+                    crate::lint_warn!("failed to read config, using default config: {}", err);
+                    return None;
+                }
+            };
+
+            match from_str(&source) {
+                Ok(config) => Some(config),
+                Err(err) => {
+                    let files = SimpleFile::new(path.to_string_lossy().into(), source);
+                    let d = if let Some(idx) = err
+                        .line_col()
+                        .and_then(|(line, col)| Some(files.line_range(0, line)?.start + col))
+                    {
+                        let pos_regex = regex::Regex::new(" at line \\d+ column \\d+$").unwrap();
+                        let msg = err.to_string();
+                        let msg = pos_regex.replace(&msg, "");
+                        Diagnostic::error(0, "config", msg).primary(idx..idx, "")
+                    } else {
+                        Diagnostic::error(0, "config", err.to_string())
+                    };
+                    crate::emit_diagnostic(&d, &files);
+                    None
+                }
+            }
         })
     }
 }

--- a/crates/rslint_errors/src/emit.rs
+++ b/crates/rslint_errors/src/emit.rs
@@ -120,21 +120,23 @@ impl<'files> Emitter<'files> {
 impl Emitter<'_> {
     /// Render and emit the diagnostic to stderr
     pub fn emit_stderr(&mut self, d: &Diagnostic, color: bool) -> Result<(), Error> {
-        let mut out = StandardStream::stderr(if color {
+        let out = StandardStream::stderr(if color {
             ColorChoice::Always
         } else {
             ColorChoice::Never
         });
+        let mut out = out.lock();
         self.emit_with_writer(d, &mut out)
     }
 
     /// Render and emit the diagnostic to stdout
     pub fn emit_stdout(&mut self, d: &Diagnostic, color: bool) -> Result<(), Error> {
-        let mut out = StandardStream::stdout(if color {
+        let out = StandardStream::stdout(if color {
             ColorChoice::Always
         } else {
             ColorChoice::Never
         });
+        let mut out = out.lock();
         self.emit_with_writer(d, &mut out)
     }
 

--- a/crates/rslint_errors/src/emit.rs
+++ b/crates/rslint_errors/src/emit.rs
@@ -119,6 +119,8 @@ impl<'files> Emitter<'files> {
 
 impl Emitter<'_> {
     /// Render and emit the diagnostic to stderr
+    ///
+    /// This method will lock stderr for the entire time it takes to emit the diagnostic.
     pub fn emit_stderr(&mut self, d: &Diagnostic, color: bool) -> Result<(), Error> {
         let out = StandardStream::stderr(if color {
             ColorChoice::Always
@@ -130,6 +132,8 @@ impl Emitter<'_> {
     }
 
     /// Render and emit the diagnostic to stdout
+    ///
+    /// This method will lock stdout for the entire time it takes to emit the diagnostic.
     pub fn emit_stdout(&mut self, d: &Diagnostic, color: bool) -> Result<(), Error> {
         let out = StandardStream::stdout(if color {
             ColorChoice::Always


### PR DESCRIPTION
Currently, config errors, that occur while reading the config or finding its path will cause a panic.
Now they will be reported to the user.

Secondly, errors that occur because of invalid Toml, are now reported with using `rslint_errors` and a primary label (if line and column info is available).

Here are some pictures:
![image](https://user-images.githubusercontent.com/39732259/96897295-bdf82580-148e-11eb-90bb-bdc63abd109f.png)
![image](https://user-images.githubusercontent.com/39732259/96897367-ce100500-148e-11eb-8b13-d817d7e1560f.png)
![image](https://user-images.githubusercontent.com/39732259/96897418-dbc58a80-148e-11eb-983b-5e0315b746ed.png)


Resolves #47 